### PR TITLE
fix: resolve nested nixpkgs attrs from omarchy-packages.json

### DIFF
--- a/config.nix
+++ b/config.nix
@@ -321,7 +321,9 @@
       '';
       description = ''
         Path to the menu-managed package list (omarchy-packages.json) folded
-        into the system at eval time. null disables menu-managed packages.
+        into the system at eval time. packages entries are nixpkgs attribute
+        paths (top-level or dotted, e.g. kdePackages.dolphin). null disables
+        menu-managed packages.
 
         There is no filesystem auto-detection: flake evaluation is pure, so
         builtins.pathExists cannot see absolute paths outside the flake

--- a/docs/options.md
+++ b/docs/options.md
@@ -180,7 +180,9 @@ the Install/Remove menu actions (`omarchy-nix-add/remove`). When set, the
 module folds the JSON's `packages` into `environment.systemPackages` and
 its `features` into the matching feature blocks (steam, tailscale,
 1password, ollama, …) at evaluation time, so menu installs are declarative
-and rollback-safe. `null` disables menu-managed packages.
+and rollback-safe. `packages` entries are nixpkgs attribute paths: a
+top-level name (`"firefox"`) or a dotted nested path
+(`"kdePackages.dolphin"`). `null` disables menu-managed packages.
 
 There is no filesystem auto-detection: flake evaluation is pure, so
 `builtins.pathExists` cannot see absolute paths outside the flake

--- a/flake.nix
+++ b/flake.nix
@@ -2132,6 +2132,67 @@ c";
                   echo "SUDO_EDITOR lost the ''${EDITOR} indirection in pam/environment"; exit 1; }
                 touch $out
               '';
+          # omarchy-nix-add writes raw nixpkgs attribute *paths* (including
+          # nested ones like kdePackages.dolphin) into omarchy-packages.json.
+          # The module must resolve dotted paths the same way catalog probes
+          # do (lib.attrByPath), not pkgs.${n} (a single top-level attr named
+          # with a literal dot). Regression: add + rebuild used to fail with
+          # "unknown nixpkgs attribute 'kdePackages.dolphin'" even though
+          # pkgs.kdePackages.dolphin exists.
+          omarchy-managed-nested-attrs =
+            let
+              inherit (pkgs) lib;
+              mkEval =
+                packages:
+                nixpkgs.lib.nixosSystem {
+                  inherit pkgs;
+                  modules = [
+                    self.nixosModules.default
+                    {
+                      omarchy.enable = true;
+                      omarchy.managedPackagesFile = builtins.toFile "omarchy-packages.json" (
+                        builtins.toJSON {
+                          inherit packages;
+                          features = [ ];
+                        }
+                      );
+                      fileSystems."/".device = "/dev/null";
+                      fileSystems."/".fsType = "ext4";
+                      boot.loader.grub.device = "nodev";
+                      system.stateVersion = "26.05";
+                    }
+                  ];
+                };
+              pkgIn =
+                needle: cfg: builtins.any (p: (p.drvPath or "") == needle.drvPath) cfg.environment.systemPackages;
+              good =
+                (mkEval [
+                  "hello"
+                  "kdePackages.dolphin"
+                ]).config;
+              missingNested = builtins.tryEval (
+                builtins.seq (builtins.concatStringsSep "" (
+                  map (p: p.drvPath or "")
+                    (mkEval [ "kdePackages.definitely-not-a-real-pkg-xyz" ]).config.environment.systemPackages
+                )) true
+              );
+              missingTop = builtins.tryEval (
+                builtins.seq (builtins.concatStringsSep "" (
+                  map (p: p.drvPath or "")
+                    (mkEval [ "definitely-not-a-real-attr-xyz" ]).config.environment.systemPackages
+                )) true
+              );
+            in
+            if !(pkgIn pkgs.hello good) then
+              throw "top-level managed attr 'hello' missing from environment.systemPackages"
+            else if !(pkgIn pkgs.kdePackages.dolphin good) then
+              throw "nested managed attr 'kdePackages.dolphin' missing from environment.systemPackages"
+            else if missingNested.success then
+              throw "unknown nested attr kdePackages.definitely-not-a-real-pkg-xyz should fail eval"
+            else if missingTop.success then
+              throw "unknown top-level attr definitely-not-a-real-attr-xyz should fail eval"
+            else
+              pkgs.runCommand "omarchy-managed-nested-attrs" { } "touch $out";
         }
       );
 

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -726,6 +726,12 @@ in
       # blocks (Task 5). Unknown names throw an eval error naming the file —
       # in the normal flow omarchy-nix-add validates before writing.
       #
+      # Names are nixpkgs attribute *paths*, not only top-level attrs:
+      # omarchy-nix-add accepts `nixpkgs#kdePackages.dolphin` (flake attr
+      # paths) and writes that string into the JSON. Resolve with
+      # attrByPath so a literal-dot pkgs.${n} lookup cannot reject a real
+      # nested package. Same split as catalog-consistency probes.
+      #
       # IMPORTANT: managedFeatures is config-dependent (it reads
       # cfg.managedPackagesFile). Referencing it at the mkMerge LIST level
       # would force it during the module system's property-pushing phase,
@@ -751,7 +757,14 @@ in
                   throw "${toString cfg.managedPackagesFile}: unknown feature '${builtins.head unknown}' (known: ${builtins.concatStringsSep ", " (builtins.attrNames managedFeatureDefs)})"
                 else
                   map (
-                    n: pkgs.${n} or (throw "${toString cfg.managedPackagesFile}: unknown nixpkgs attribute '${n}'")
+                    n:
+                    let
+                      path = lib.splitString "." n;
+                    in
+                    if lib.hasAttrByPath path pkgs then
+                      lib.getAttrFromPath path pkgs
+                    else
+                      throw "${toString cfg.managedPackagesFile}: unknown nixpkgs attribute '${n}'"
                   ) managedPkgs;
             }
           ]

--- a/skills/omarchy/SKILL.md
+++ b/skills/omarchy/SKILL.md
@@ -175,9 +175,10 @@ omarchy-nix-remove [catalog-id-or-nixpkgs-attribute]
 
 They update `omarchy-packages.json` beside the consumer flake and rebuild.
 Use `omarchy-nix-search` for an interactive nixpkgs search. Use a catalog ID
-when automating an opinionated menu choice. If the consumer manages packages
-directly in Nix, edit its configuration and follow its own validation and
-deployment instructions.
+when automating an opinionated menu choice. Raw nixpkgs names may be
+top-level (`ripgrep`) or nested attribute paths (`kdePackages.dolphin`).
+If the consumer manages packages directly in Nix, edit its configuration
+and follow its own validation and deployment instructions.
 
 Add/remove operations are transactional: a per-file lock serializes them,
 the JSON is written atomically, a failed rebuild rolls back only that
@@ -429,6 +430,8 @@ for:
 - "Change the UI font" → `omarchy font list`, then `omarchy font set <name>`
 - "Install Firefox" → `omarchy-nix-add install.browser.firefox` (or
   `omarchy-nix-search` interactively), never `omarchy pkg add`
+- "Install Dolphin" → `omarchy-nix-add kdePackages.dolphin` (nested
+  nixpkgs attribute path; not a catalog ID)
 - "Install a dev database" → no catalog entry exists for databases/docker:
   enable them in the consumer flake (e.g. `virtualisation.docker.enable =
   true;`) and rebuild; a direct `omarchy install ...` may be a


### PR DESCRIPTION
omarchy-nix-add accepts flake attr paths like kdePackages.dolphin (nix eval nixpkgs#kdePackages.dolphin.name succeeds) and writes that string into omarchy-packages.json. The module then looked the name up as pkgs.${n}, a single top-level attribute with a literal dot, so rebuilds failed with "unknown nixpkgs attribute 'kdePackages.dolphin'" and rolled the JSON back.

Resolve names with lib.splitString / hasAttrByPath / getAttrFromPath, matching catalog-consistency probes. Unknown paths still throw the same error. Regression check covers top-level hello, nested kdePackages.dolphin, and missing names of both shapes.

Btw this project is incredible, i switched my main laptop already and have such a great time checking everything out. Thank you!