### PR TITLE
fix: search NixOS application dirs in omarchy-launch-webapp

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2132,6 +2132,39 @@ c";
                   echo "SUDO_EDITOR lost the ''${EDITOR} indirection in pam/environment"; exit 1; }
                 touch $out
               '';
+          # omarchy-launch-browser and omarchy-launch-webapp resolve the
+          # default/chromium .desktop via a fixed brace list of data dirs.
+          # Arch has /usr/share/applications; NixOS puts system apps in
+          # /run/current-system/sw/share/applications. Both launchers must
+          # search that path — webapps used to drop the Exec= lookup, so
+          # uwsm-app treated --app=https://… as the application path.
+          omarchy-launch-desktop-glob =
+            let
+              omarchyPkg = self.packages.${system}.omarchy;
+              nixosGlob = "{~/.local,~/.nix-profile,/run/current-system/sw,/usr}/share/applications";
+              archGlob = "{~/.local,~/.nix-profile,/usr}/share/applications";
+            in
+            pkgs.runCommand "omarchy-launch-desktop-glob" { } ''
+              webapp=${omarchyPkg}/share/omarchy/bin/omarchy-launch-webapp
+              browser=${omarchyPkg}/share/omarchy/bin/omarchy-launch-browser
+              grep -Fq '${nixosGlob}' "$webapp" || {
+                echo "omarchy-launch-webapp missing NixOS applications glob" >&2
+                exit 1
+              }
+              grep -Fq '${nixosGlob}' "$browser" || {
+                echo "omarchy-launch-browser missing NixOS applications glob" >&2
+                exit 1
+              }
+              grep -Fq '${archGlob}' "$webapp" && {
+                echo "omarchy-launch-webapp still has the Arch-only applications glob" >&2
+                exit 1
+              }
+              grep -Fq '${archGlob}' "$browser" && {
+                echo "omarchy-launch-browser still has the Arch-only applications glob" >&2
+                exit 1
+              }
+              touch $out
+            '';
         }
       );
 

--- a/pkgs/omarchy.nix
+++ b/pkgs/omarchy.nix
@@ -168,11 +168,13 @@ stdenv.mkDerivation (finalAttrs: {
           --replace-fail "/usr/bin/omarchy-tailscale-receive" \
             "$out/share/omarchy/bin/omarchy-tailscale-receive"
 
-        # omarchy-launch-browser resolves the .desktop via a fixed brace list of
-        # data dirs. Arch has /usr/share/applications; NixOS puts system apps in
-        # /run/current-system/sw/share/applications. Add that path so chromium
-        # (and any other default) resolves after xdg-settings.
-        substituteInPlace bin/omarchy-launch-browser \
+        # omarchy-launch-browser and omarchy-launch-webapp resolve the .desktop
+        # via a fixed brace list of data dirs. Arch has /usr/share/applications;
+        # NixOS puts system apps in /run/current-system/sw/share/applications.
+        # Add that path so chromium (and any other default) resolves after
+        # xdg-settings. Webapps used to skip the Exec= lookup and hand
+        # --app=https://… to uwsm-app as the application path.
+        substituteInPlace bin/omarchy-launch-browser bin/omarchy-launch-webapp \
           --replace-fail \
             '{~/.local,~/.nix-profile,/usr}/share/applications' \
             '{~/.local,~/.nix-profile,/run/current-system/sw,/usr}/share/applications'


### PR DESCRIPTION
omarchy-launch-browser was already rewritten to look up .desktop files under /run/current-system/sw/share/applications. omarchy-launch-webapp kept the Arch-only brace list (~/.local, ~/.nix-profile, /usr), so the chromium Exec= lookup was empty on NixOS.

uwsm-app then received `-- --app=https://x.com/` and reported "Path --app=https://x.com does not exist", which is Super+Shift+X and every other webapp bind.

Apply the same glob to both launchers. Regression check asserts the packaged scripts contain the NixOS path and no longer contain the Arch-only glob.