### PR TITLE
Order NetworkManager before the graphical session

### DIFF
--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1144,6 +1144,20 @@ in
         networking.networkmanager.enable = lib.mkDefault true;
         hardware.bluetooth.enable = lib.mkDefault true;
 
+        # Order NetworkManager ahead of the display manager -- and so ahead
+        # of the graphical session and quickshell. The shell binds its
+        # Quickshell.Networking backend to NetworkManager's D-Bus name once,
+        # at process start, and quickshell 0.3.0 has no NameOwnerChanged
+        # recovery (basecamp/omarchy#7324). If the session wins the startup
+        # race on a first boot, the network panel shows NOT CONNECTED while
+        # the link is up (live IP/ping stats from the status poller), and the
+        # first-run DHCP click no-ops until the shell is restarted.
+        # Before= is ordering only -- no Requires= -- so a failed
+        # NetworkManager never blocks reaching the login screen.
+        systemd.services.NetworkManager = lib.mkIf config.networking.networkmanager.enable {
+          before = [ "display-manager.service" ];
+        };
+
         # External monitor brightness over DDC/CI (omarchy-brightness-display-ddc).
         # Loads i2c-dev and creates the i2c group; the user still needs to be
         # in that group (consumer's users.users.<name>.extraGroups, same model


### PR DESCRIPTION
## Summary
Quickshell binds `Quickshell.Networking` to NetworkManager's D-Bus name once at process start. Quickshell 0.3.0 has no NameOwnerChanged recovery ([omarchy#7324](https://github.com/basecamp/omarchy/issues/7324)). If the session wins the startup race (or NM comes up late), the network panel paints **NOT CONNECTED** while `omarchy-network-status` is truthful.

This orders `NetworkManager.service` before `display-manager.service` (and so before the uwsm Hyprland session / `omarchy-launch-shell`) so the bus is up before the shell binds. **Before= only** — no Requires — so a failed NM does not block the login screen.

QML defense lives upstream: [omacom/omarchy#9923](https://github.com/omacom/omarchy/pull/9923). This PR does **not** vendor-patch QML in `pkgs/`. No SDDM/VT changes. No Tailscale/VPN ethernet rewrite. Does not `nixos-rebuild switch`.

## Test plan
- [ ] `nix flake check` green (ran on lathe @ `4f7329f`: all checks passed).
- [ ] With NM connected (State=70), a fresh session should not start quickshell against a dead NM bus.
- [ ] No SDDM / Tailscale / vendored QML diffs.