### PR TITLE
fix: put omarchy-shell on omarchy-sleep-lock PATH

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -730,6 +730,39 @@
               throw "demo config has omarchy-lock-fingerprint without omarchy.fingerprint.enable"
             else
               pkgs.runCommand "omarchy-pam-eval" { } "touch $out";
+          # omarchy-sleep-lock holds a delay inhibitor, then execs
+          # omarchy-system-sleep-lock, which talks to the running shell via
+          # bare `omarchy-shell` / `qs` / `jq`. User-unit PATH is sparse;
+          # missing those binaries means the lock request never lands and
+          # the machine suspends unlocked.
+          omarchy-sleep-lock-path =
+            let
+              pathPkgs = self.nixosConfigurations.demo.config.systemd.user.services.omarchy-sleep-lock.path;
+              pathValue = nixpkgs.lib.makeBinPath pathPkgs;
+              required = [
+                "omarchy-shell"
+                "qs"
+                "jq"
+                "hyprctl"
+                "omarchy-notification-send"
+                "omarchy-hyprland-monitor-clamshell"
+              ];
+            in
+            pkgs.runCommand "omarchy-sleep-lock-path" { } ''
+              export PATH=${nixpkgs.lib.escapeShellArg pathValue}
+              missing=0
+              for cmd in ${nixpkgs.lib.concatStringsSep " " required}; do
+                if ! command -v "$cmd" >/dev/null; then
+                  echo "omarchy-sleep-lock PATH missing $cmd" >&2
+                  missing=1
+                fi
+              done
+              if [ "$missing" != 0 ]; then
+                echo "PATH was: $PATH" >&2
+                exit 1
+              fi
+              touch $out
+            '';
           # binfmt plumbing: the opt-in list must stay empty on
           # the demo config (no silent emulation) and reach
           # boot.binfmt.emulatedSystems unchanged when set. extendModules

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1334,17 +1334,30 @@ in
               ExecStart = "${cfg.package}/share/omarchy/bin/omarchy-migrate";
             };
           };
-          # sleep-lock script execs bare `bash`, `systemd-inhibit`, and
-          # `dbus-monitor`. User-unit PATH is sparse (no /run/current-system
-          # unless hyprland setPath is on), so put them on the unit PATH
-          # rather than rewriting the vendored script body.
+          # sleep-lock monitor execs bare `bash`, `systemd-inhibit`, and
+          # `dbus-monitor`. On PrepareForSleep it then runs
+          # omarchy-system-sleep-lock, which talks to the shell via bare
+          # `omarchy-shell` / `qs` / `jq` and notifies via
+          # `omarchy-notification-send`. User-unit PATH is sparse (no
+          # /run/current-system unless hyprland setPath is on), so put them
+          # on the unit PATH rather than rewriting the vendored script body.
+          # Hyprland is programs.hyprland.package (same as omarchy-migrate)
+          # so hyprctl matches the running compositor. The last entry
+          # resolves to $pkg/share/omarchy/bin.
           omarchy-sleep-lock = {
             wantedBy = [ "graphical-session.target" ];
-            path = with pkgs; [
-              bash
-              systemd
-              dbus
-            ];
+            path =
+              (with pkgs; [
+                bash
+                systemd
+                dbus
+                jq
+                quickshell
+              ])
+              ++ [
+                config.programs.hyprland.package
+                "${cfg.package}/share/omarchy"
+              ];
           };
           omarchy-recover-internal-monitor.wantedBy = [ "graphical-session-pre.target" ];
           # crash-watch: the v4.0.0 journal-fed coredump watcher (crash toast

--- a/tests/ux.nix
+++ b/tests/ux.nix
@@ -654,6 +654,25 @@
         as_demo("systemctl --user is-active --quiet omarchy-sleep-lock.service"),
         timeout=60,
     )
+    # The monitor execs omarchy-system-sleep-lock, which talks to the shell
+    # via bare omarchy-shell/qs/jq. A sparse unit PATH lets suspend proceed
+    # unlocked. Eval-time checks.omarchy-sleep-lock-path covers the option;
+    # this asserts the live generated unit.
+    sleep_env = machine.succeed(
+        as_demo("systemctl --user show -p Environment --value omarchy-sleep-lock.service")
+    ).strip()
+    sleep_path = ""
+    for item in sleep_env.split(" "):
+        if item.startswith("PATH="):
+            sleep_path = item[len("PATH="):]
+    assert sleep_path, (
+        "omarchy-sleep-lock.service has no PATH in Environment: %r" % sleep_env
+    )
+    for cmd in ("omarchy-shell", "qs", "jq"):
+        status, _ = machine.execute("PATH=%s command -v %s" % (sleep_path, cmd))
+        assert status == 0, (
+            "omarchy-sleep-lock PATH missing %s: %s" % (cmd, sleep_path)
+        )
     fcitx_load = machine.succeed(
         as_demo("systemctl --user show -p LoadState --value omarchy-fcitx5.service")
     ).strip()


### PR DESCRIPTION
The sleep-lock unit PATH only had bash/systemd/dbus, enough for the monitor but not for omarchy-system-sleep-lock. Bare omarchy-shell/qs/jq were command-not-found, so the lock request never reached Quickshell and logind suspended the session unlocked after InhibitDelayMax.

Add jq, quickshell, Hyprland (hyprctl), and $OMARCHY_PATH/bin to the unit PATH, matching omarchy-migrate. Guarded by
checks.omarchy-sleep-lock-path and the omarchy-ux live-unit assertion.

nix flake check passes, including omarchy-desktop and omarchy-ux.