### PR TITLE
omarchy update: default the rebuild to boot (switch kills the updater on session restarts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,17 @@ pulled for updates). An evaluation failure keeps the candidate instead of
 silently skipping it. An explicit `OMARCHY_NIX_FLAKE` that is invalid fails
 with diagnostics rather than falling back to another checkout.
 
+`omarchy update` rebuilds with **`boot`, not `switch`, by default**: a
+`switch` on a large nixpkgs jump legitimately restarts the user session
+(pipewire, portals, uwsm plumbing), which kills the updater itself — it runs
+attached to a terminal inside that session — and silently skips every
+post-rebuild step (migrations, post-update hooks, status, the reboot
+prompt). `boot` never touches running units; the reboot prompt at the end of
+the update activates the new generation atomically. Set
+`OMARCHY_NIX_REBUILD_CMD=switch` to restore live activation for small
+updates. `omarchy-nix-add`/`omarchy-nix-remove` keep `switch` — their delta
+rarely restarts the session.
+
 ### What `omarchy.enable = true` does
 
 System (NixOS module): the vendored upstream tree on the system profile

--- a/pkgs/omarchy.nix
+++ b/pkgs/omarchy.nix
@@ -1093,7 +1093,16 @@ stdenv.mkDerivation (finalAttrs: {
       fi
     }
 
-    rebuild_cmd="''${OMARCHY_NIX_REBUILD_CMD:-switch}"
+    # Default boot, not switch: a switch on a large nixpkgs jump restarts
+    # the user session (pipewire, portals, uwsm plumbing), killing this
+    # updater mid-flow — everything after the rebuild (migrations,
+    # post-update hooks, status, the reboot prompt) would be silently
+    # skipped, because omarchy-update runs attached to a terminal inside
+    # that session. boot never touches running units, so the updater
+    # survives; the reboot prompt at the end of omarchy update activates
+    # the new generation atomically. OMARCHY_NIX_REBUILD_CMD=switch
+    # restores live activation.
+    rebuild_cmd="''${OMARCHY_NIX_REBUILD_CMD:-boot}"
 
     # The setuid sudo wrapper (/run/wrappers/bin/sudo) is provided by the
     # sourced omarchy-nix-pkglib.
@@ -1109,6 +1118,9 @@ stdenv.mkDerivation (finalAttrs: {
       run_or_print sudo nix flake update --flake "$flake_dir"
     fi
     run_or_print sudo nixos-rebuild "$rebuild_cmd" --flake "$flake_dir"
+    if [[ $rebuild_cmd == boot && ''${OMARCHY_NIX_UPDATE_DRY_RUN:-} != 1 ]]; then
+      echo "Boot default set — the new generation activates on reboot (offered at the end of omarchy update when the kernel changed)."
+    fi
     echo
     EOF
         chmod +x bin/omarchy-update-system-pkgs

--- a/skills/omarchy/SKILL.md
+++ b/skills/omarchy/SKILL.md
@@ -192,12 +192,19 @@ and `nixos-rebuild` internally. Useful controls:
 
 ```bash
 OMARCHY_NIX_FLAKE=/path/to/config omarchy update
-OMARCHY_NIX_REBUILD_CMD=build omarchy update
+OMARCHY_NIX_REBUILD_CMD=switch omarchy update   # live activation; default is boot
 OMARCHY_NIX_SKIP_FLAKE_UPDATE=1 omarchy update
 OMARCHY_NIX_UPDATE_DRY_RUN=1 omarchy update
 ```
 
-Review a dry run or `build` before a risky deployment. The full
+The update defaults to `boot` (never touches running units): a `switch` on
+a large nixpkgs jump restarts the graphical session and kills the updater
+mid-flow, silently skipping migrations/hooks/status (see issue #6). The
+reboot prompt at the end of the update activates the new generation (it
+fires when the kernel or Hyprland changed; otherwise the notice above is
+the signal).
+
+Review a dry run before a risky deployment. The full
 update wrapper can still run Omarchy migrations and hooks; a dry-run variable
 only suppresses the Nix update/rebuild core.
 


### PR DESCRIPTION
Fixes #6.

## What

`omarchy-update-system-pkgs` rebuilds with `boot` instead of `switch` by default
(`OMARCHY_NIX_REBUILD_CMD=switch` restores live activation). `omarchy-nix-add` /
`omarchy-nix-remove` keep `switch` — their delta rarely restarts the session.
A notice prints after the rebuild (not under DRY-RUN) so the boot-pending state
is visible. README + skills/omarchy/SKILL.md updated.

## Why

A `switch` on a large nixpkgs jump legitimately restarts user units (pipewire,
portals, uwsm session plumbing). The updater runs attached to a terminal inside
that session (`script -qefc` in omarchy-update), so the switch kills it
mid-flow: activation completes, but everything after `omarchy-update-system-pkgs`
— `omarchy-migrate`, `omarchy-hook post-update`, `omarchy-update-mise`,
`omarchy-update-analyze-logs`, `omarchy-update-status`,
`omarchy-update-restart` — is silently skipped. Reproduced on NixOS 26.05 with
nixpkgs 26.05.20260811 → 26.05.20260911 (log excerpt in #6). Detaching the
rebuild instead (systemd-run) conflicts with the interactive sudo password.

`boot` never touches running units, so the updater survives and the flow
completes.

## Disclosed caveats (reviewed, pre-existing or accepted)

- **Migrations run one update late — pre-existing, not introduced here.** The
  module pins OMARCHY_PATH to the package's store path, so the updater inherits
  the OLD generation's tree and `omarchy-migrate` reads the old
  (already-applied) migration set under `switch` as well. Follow-up candidate:
  session OMARCHY_PATH via /run/current-system, or exporting the new profile
  path post-rebuild.
- **Reboot prompt scope.** `omarchy-update-restart` prompts on kernel/Hyprland
  changes or the reboot-required marker. For deltas without those, the
  in-script notice is the signal that the generation activates on the next
  reboot. Touching the marker here was deliberately avoided — nothing in-tree
  creates/clears it on NixOS yet; its lifecycle should be established first.

## Validation

- `nix build .#omarchy` clean; generated `omarchy-update-system-pkgs` passes
  `bash -n`, verified to contain the `boot` default + guarded notice.
- `tests/ux.nix` DRY-RUN assertions unaffected (they target omarchy-migrate
  output; nothing asserts the rebuild default).
- Design rule respected: the edit lives in the NixOS-injected script inside the
  vendoring derivation, not in vendored upstream code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)